### PR TITLE
Work with new versions of React which don't have PropTypes included

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-data-table",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A generic table to lay out data from realm for react native",
   "repository": "https://github.com/sussol/react-native-data-table.git",
   "author": "Sustainable Solutions (NZ) Ltd.",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "react-native-vector-icons": "^2.0.2"
+    "react-native-vector-icons": "^4.4.2"
   },
   "devDependencies": {
     "babel-core": "^6.17.0",


### PR DESCRIPTION
Currently, although this module has been refactored to use the prop-types library it does not work with modern versions of React because it uses an old version of react-native-vector-icons. The dependency needs to be version 4.1 or above https://github.com/oblador/react-native-vector-icons/releases/tag/v4.1.0 to work.