### PR TITLE
improve accessibility of header/rows for web

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -38,7 +38,7 @@ export class DataTable extends React.Component {
     } = this.props;
 
     return (
-      <View style={[defaultStyles.verticalContainer, style]}>
+      <View accessibilityRole="table" style={[defaultStyles.verticalContainer, style]}>
         {typeof renderHeader === 'function' && renderHeader()}
         <ListView
           {...listViewProps}

--- a/src/Header.js
+++ b/src/Header.js
@@ -11,12 +11,14 @@ import {
   StyleSheet,
   View,
   ViewPropTypes,
+  Platform,
 } from 'react-native';
 
 export function Header(props) {
   const { children, style, ...viewProps } = props;
+  const webProps = Platform.OS === 'web' ? { "aria-header": true } : null;
   return (
-    <View {...viewProps} style={[defaultStyles.header, style]}>
+    <View {...viewProps} {...webProps} style={[defaultStyles.header, style]}>
       {children}
     </View>
   );

--- a/src/Row.js
+++ b/src/Row.js
@@ -12,6 +12,7 @@ import {
   ViewPropTypes,
   StyleSheet,
   TouchableOpacity,
+  Platform,
 } from 'react-native';
 
 export class Row extends React.Component {
@@ -37,6 +38,8 @@ export class Row extends React.Component {
   render() {
     const { style, expandedRowStyle, children, renderExpansion, onPress, ...touchableOpacityProps } = this.props;
     const rowStyle = this.state.isExpanded && expandedRowStyle ? expandedRowStyle : style;
+    const webProps = Platform.OS === 'web' ? { "aria-row": true } : null;
+
     if (renderExpansion) {
       return (
         <TouchableOpacity
@@ -44,7 +47,7 @@ export class Row extends React.Component {
           style={[defaultStyles.row, rowStyle]}
           onPress={this.onPress}
         >
-          <View style={defaultStyles.cellContainer}>
+          <View {...webProps} style={defaultStyles.cellContainer}>
             {children}
           </View>
           {this.state.isExpanded && renderExpansion()}
@@ -63,7 +66,7 @@ export class Row extends React.Component {
       );
     }
     return (
-      <View style={[defaultStyles.row, { flexDirection: 'row' }, rowStyle]}>
+      <View {...webProps} style={[defaultStyles.row, { flexDirection: 'row' }, rowStyle]}>
         {children}
       </View>
     );


### PR DESCRIPTION
Add some aria support for web as rendered component does not use table HTML.  Changes should render rendered data table 508 compliant.
 
+ Add aria to Header and Row components when web.
+ Add accessibilityRole to DataTable component