### PR TITLE
listViewStyle is supposed to be Object

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -54,7 +54,7 @@ export class DataTable extends React.Component {
 
 DataTable.propTypes = {
   style: ViewPropTypes.style,
-  listViewStyle: PropTypes.number,
+  listViewStyle: PropTypes.object,
   refCallback: PropTypes.func,
   renderHeader: PropTypes.func,
   dataSource: PropTypes.object.isRequired,


### PR DESCRIPTION
Having listViewStyle typed as number causes a series of errors.

```
Warning: Failed prop type: Invalid prop `listViewStyle` of type `object` supplied to `DataTable`, expected `number`.
    in DataTable (at react-native-generic-table-page/index.js:459)
    in GenericTablePage (at GenericPage.js:67)
```